### PR TITLE
Changes necessary to fix `GrepAdd` issue #1

### DIFF
--- a/plugin/EasyGrep.vim
+++ b/plugin/EasyGrep.vim
@@ -2533,7 +2533,7 @@ function! s:WarnNoMatches(pattern)
     elseif s:IsModeAll()
         let fpat = "*"
     else
-        let fpat = s:GetFileTargetList(0)
+        let fpat = join(s:GetFileTargetList(0), ', ')
     endif
 
     let r = g:EasyGrepRecursive ? " (+Recursive)" : ""


### PR DESCRIPTION
This pull request

Changes the way `s:GetGrepCommandLine` places the `!` character. Instead returning `lgrep!add` it returns `lgrepadd!` now.

Changes `let fpat = s:GetFileTargetList(0)` to assign a string which is what `s:Warning` expects.
