### PR TITLE
Fix for messy vim rendering when returning from <Leader>vv with EasyGrepCommand set to 1.

### DIFF
--- a/plugin/EasyGrep.vim
+++ b/plugin/EasyGrep.vim
@@ -2480,6 +2480,9 @@ function! s:DoGrep(pattern, add, whole, count, escapeArgs)
         let failed = 1
     endtry
 
+    " In some cases the colors of vim's layout might be borked, so force vim to redraw:
+    redraw!
+
     call s:RestoreGrepVariables()
     if failed
         return 0


### PR DESCRIPTION
Additional info:
When using EasyGrep with EasyGrepCommand set to 1, the rendering of vim (i.e. font and background colors) is all messy when it returns from the bash shell into vim. For example:
before <Leader> vv https://dl.dropboxusercontent.com/u/4664802/easygrep-before.png
after <Leader> vv https://dl.dropboxusercontent.com/u/4664802/easygrep-issue.png
redraw! (exclamation mark is important) fixed this

Note that this issue is actually mentioned in :help silent:
_":silent" will also avoid the hit-enter prompt.  When using this for
an external command, this may cause the screen to be messed up.  Use
|CTRL-L| to clean it up then._
