### PR TITLE
add perl style regexp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ Commands:
           3. A user specified directory. The search location is fixed and does
              not change.
 
+## Using Easygrep with perl style regexp
+
+you may use perl style regexp while using Easygrep, simply:
+
+1. have https://github.com/othree/eregex.vim installed
+1. have `let g:EasyGrepCommand=1` and `grepprg` been set properly
+1. have `let g:EasyGrepPerlStyle=1`
+
+
 ## Screencast
 
 ![Alt text](https://cloud.githubusercontent.com/assets/2375604/9804914/d0c39ff0-5800-11e5-8e7d-b77543bf2dcf.gif "EasyGrep demo")

--- a/doc/EasyGrep.txt
+++ b/doc/EasyGrep.txt
@@ -305,6 +305,7 @@ o |EasyGrepFileAssociations|            - Specifies the location of the EasyGrep
                                         file associations
 o |EasyGrepMode|                        - Mode of operation
 o |EasyGrepCommand|                     - Whether to use vimgrep or grepprg
+o |EasyGrepPerlStyle|                   - Whether to use perl style regexp
 o |EasyGrepRecursive|                   - Recursive searching
 o |EasyGrepIgnoreCase|                  - Case-sensitivity in searches
 o |EasyGrepHidden|                      - Include hidden files in searches
@@ -424,6 +425,20 @@ command will be used.  This command inspects the 'grepprg' variable to
 determine the external tool that will be used for the search. Note that an
 external tool is often faster to search than vimgrep (see
 |EasyGrep_Performance|).
+
+*EasyGrepPerlStyle*  [default=0]
+Whether to use perl style regexp (in :Grep and :Replace).
+
+0 - use "grep"
+1 - use "grep -P"
+
+require these to make this work:
+set *EasyGrepCommand* to 1
+have https://github.com/othree/eregex.vim installed
+
+known issues:
+\b should replaced by \< and \>
+\c \C \i \I and \v \V \m \M won't work properly
 
 *EasyGrepRecursive*  [default=0]
 Specifies that recursive search be activated on start.

--- a/doc/EasyGrep.txt
+++ b/doc/EasyGrep.txt
@@ -433,7 +433,7 @@ Whether to use perl style regexp (in :Grep and :Replace).
 1 - use "grep -P"
 
 require these to make this work:
-set *EasyGrepCommand* to 1
+set |EasyGrepCommand| to 1
 have https://github.com/othree/eregex.vim installed
 
 known issues:

--- a/plugin/EasyGrep.vim
+++ b/plugin/EasyGrep.vim
@@ -2892,7 +2892,13 @@ function! s:DoReplace(target, replacement, wholeword, escapeArgs)
         let target = "\\<".target."\\>"
     endif
     if exists("g:EasyGrepCommand") && g:EasyGrepCommand==1 && exists("g:EasyGrepPerlStyle") && g:EasyGrepPerlStyle==1
-        let target=E2v(target)
+        try
+            let target=E2v(target)
+        catch
+            echomsg "Warning: Replace by perl style regexp require othree/eregex.vim"
+            let dummy = getchar()
+            return
+        endtry
     endif
 
     let finished = 0

--- a/plugin/EasyGrep.vim
+++ b/plugin/EasyGrep.vim
@@ -2676,6 +2676,7 @@ function! s:DoGrep(pattern, add, wholeword, count, escapeArgs, xgrep)
     let l:pattern = a:pattern
     let l:pattern = substitute(l:pattern, '\\<', '\\b', 'g')
     let l:pattern = substitute(l:pattern, '\\>', '\\b', 'g')
+    let l:pattern = substitute(l:pattern, '\\', '\\\\', 'g')
 
     call s:CreateGrepDictionary()
 

--- a/plugin/EasyGrep.vim
+++ b/plugin/EasyGrep.vim
@@ -2571,6 +2571,10 @@ function! s:GetGrepCommandLine(pattern, add, wholeword, count, escapeArgs, filte
         let opts .= s:CommandParameterOr(commandParams, "opt_str_wholewordoption", "")
     endif
 
+    if exists("g:EasyGrepCommand") && g:EasyGrepCommand==1 && exists("g:EasyGrepPerlStyle") && g:EasyGrepPerlStyle==1
+        let opts .= "-P "
+    endif
+
     if s:IsRecursiveSearch()
         if s:CommandHasLen("req_str_recurse")
             let opts .= commandParams["req_str_recurse"]." "
@@ -2880,6 +2884,9 @@ function! s:DoReplace(target, replacement, wholeword, escapeArgs)
 
     if wholeword
         let target = "\\<".target."\\>"
+    endif
+    if exists("g:EasyGrepCommand") && g:EasyGrepCommand==1 && exists("g:EasyGrepPerlStyle") && g:EasyGrepPerlStyle==1
+        let target=E2v(target)
     endif
 
     let finished = 0

--- a/plugin/EasyGrep.vim
+++ b/plugin/EasyGrep.vim
@@ -2677,6 +2677,7 @@ function! s:DoGrep(pattern, add, wholeword, count, escapeArgs, xgrep)
     let l:pattern = substitute(l:pattern, '\\<', '\\b', 'g')
     let l:pattern = substitute(l:pattern, '\\>', '\\b', 'g')
     let l:pattern = substitute(l:pattern, '\\', '\\\\', 'g')
+    let l:pattern = substitute(l:pattern, '%', '\\%', 'g')
 
     call s:CreateGrepDictionary()
 

--- a/plugin/EasyGrep.vim
+++ b/plugin/EasyGrep.vim
@@ -2082,6 +2082,7 @@ function! s:Replace(bang, argv)
     elseif l > 3 && a:argv[0] == '/'
         let ph = tempname()
         let ph = substitute(ph, '/', '_', 'g')
+        let ph = substitute(ph, '\\', '_', 'g')
         let temp = substitute(a:argv, '\\/', ph, "g")
         let l = len(temp)
         if temp[l-1] != '/'

--- a/plugin/EasyGrep.vim
+++ b/plugin/EasyGrep.vim
@@ -2673,6 +2673,10 @@ endfunction
 " }}}
 " DoGrep {{{
 function! s:DoGrep(pattern, add, wholeword, count, escapeArgs, xgrep)
+    let l:pattern = a:pattern
+    let l:pattern = substitute(l:pattern, '\\<', '\\b', 'g')
+    let l:pattern = substitute(l:pattern, '\\>', '\\b', 'g')
+
     call s:CreateGrepDictionary()
 
     if s:OptionsExplorerOpen == 1
@@ -2680,7 +2684,7 @@ function! s:DoGrep(pattern, add, wholeword, count, escapeArgs, xgrep)
         return 0
     endif
 
-    if !s:HasTargetsThatMatch(a:pattern)
+    if !s:HasTargetsThatMatch(l:pattern)
         return 0
     endif
 
@@ -2690,7 +2694,7 @@ function! s:DoGrep(pattern, add, wholeword, count, escapeArgs, xgrep)
     endif
 
     call s:SetGrepVariables(commandName)
-    let grepCommand = s:GetGrepCommandLine(a:pattern, a:add, a:wholeword, a:count, a:escapeArgs, 1, a:xgrep)
+    let grepCommand = s:GetGrepCommandLine(l:pattern, a:add, a:wholeword, a:count, a:escapeArgs, 1, a:xgrep)
 
     " change directory to the grep root before executing
     call s:ChangeDirectoryToGrepRoot()


### PR DESCRIPTION
`:Grep` and `:Replace` would use perl style regexp if:
* `EasyGrepCommand` is set to 1
* `EasyGrepPerlStyle` is set to 1
* require: https://github.com/othree/eregex.vim

vim style:
```
:Grep \<edit\%(\(ing\)\)\@=
```

perl style:
```
:Grep \<edit(?=(ing))
```