### PR TITLE
add perl style regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ Commands:
           3. A user specified directory. The search location is fixed and does
              not change.
 
+## Using Easygrep with perl style regexp
+
+you may use perl style regexp while using Easygrep, simply:
+
+1. have https://github.com/othree/eregex.vim installed
+1. have `let g:EasyGrepCommand=1` and `grepprg` been set properly
+1. have `let g:EasyGrepPerlStyle=1`
+
+
 ## Screencast
 
 ![Alt text](https://cloud.githubusercontent.com/assets/2375604/9804914/d0c39ff0-5800-11e5-8e7d-b77543bf2dcf.gif "EasyGrep demo")

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ you may use perl style regexp while using Easygrep, simply:
 1. have https://github.com/othree/eregex.vim installed
 1. have `let g:EasyGrepCommand=1` and `grepprg` been set properly
 1. have `let g:EasyGrepPerlStyle=1`
+1. also make sure you have GNU grep greater than 2.5.3
 
 
 ## Screencast

--- a/doc/EasyGrep.txt
+++ b/doc/EasyGrep.txt
@@ -435,6 +435,7 @@ Whether to use perl style regexp (in :Grep and :Replace).
 require these to make this work:
 set |EasyGrepCommand| to 1
 have https://github.com/othree/eregex.vim installed
+support only GNU grep (greater than 2.5.3)
 
 known issues:
 \b should replaced by \< and \>

--- a/doc/EasyGrep.txt
+++ b/doc/EasyGrep.txt
@@ -330,6 +330,7 @@ o |EasyGrepReplaceAllPerFile|           - Replace on per file or global basis
 o |EasyGrepOptionPrefix|                - Specify the keymap for toggling options
 o |EasyGrepExtraWarnings|               - Whether to show extra warnings
 o |EasyGrepDefaultUserPattern|          - The default 'User' mode pattern
+o |EasyGrepDisableCmdParam|             - whether disable grep cmd param
 
 
 ------------------------------------------------------------------------------
@@ -549,6 +550,9 @@ the potential to confuse some users.
 Specifies the default pattern for 'User' mode. (see |EasyGrepMode| and
 |EasyGrep_OperationModes|).  This pattern must be defined and non-empty if
 |EasyGrepMode| is set to start in 'User' mode.
+
+*EasyGrepDisableCmdParam*  [default=""]
+if set to 1, disable cmd param such as '-i' to ignore case when :Grep.
 
 ==============================================================================
   6. Supported Programs                                    *EasyGrep_Programs*

--- a/doc/EasyGrep.txt
+++ b/doc/EasyGrep.txt
@@ -305,6 +305,7 @@ o |EasyGrepFileAssociations|            - Specifies the location of the EasyGrep
                                         file associations
 o |EasyGrepMode|                        - Mode of operation
 o |EasyGrepCommand|                     - Whether to use vimgrep or grepprg
+o |EasyGrepPerlStyle|                   - Whether to use perl style regexp
 o |EasyGrepRecursive|                   - Recursive searching
 o |EasyGrepIgnoreCase|                  - Case-sensitivity in searches
 o |EasyGrepHidden|                      - Include hidden files in searches
@@ -424,6 +425,20 @@ command will be used.  This command inspects the 'grepprg' variable to
 determine the external tool that will be used for the search. Note that an
 external tool is often faster to search than vimgrep (see
 |EasyGrep_Performance|).
+
+*EasyGrepPerlStyle*  [default=0]
+Whether to use perl style regexp (in :Grep and :Replace).
+
+0 - use "grep"
+1 - use "grep -P"
+
+require these to make this work:
+set |EasyGrepCommand| to 1
+have https://github.com/othree/eregex.vim installed
+
+known issues:
+\b should replaced by \< and \>
+\c \C \i \I and \v \V \m \M won't work properly
 
 *EasyGrepRecursive*  [default=0]
 Specifies that recursive search be activated on start.

--- a/plugin/EasyGrep.vim
+++ b/plugin/EasyGrep.vim
@@ -2612,7 +2612,7 @@ function! s:GetGrepCommandLine(pattern, add, wholeword, count, escapeArgs, filte
         endif
     endif
 
-    if g:EasyGrepIgnoreCase
+    if g:EasyGrepIgnoreCase && !(&smartcase && match(a:pattern, '[A-Z]') >= 0)
         if s:CommandHasLen("req_str_caseignore")
             let opts .= commandParams["req_str_caseignore"]." "
         endif

--- a/plugin/EasyGrep.vim
+++ b/plugin/EasyGrep.vim
@@ -2573,6 +2573,7 @@ function! s:GetGrepCommandLine(pattern, add, wholeword, count, escapeArgs, filte
     let commandParams = s:GetGrepCommandParameters()
 
     if exists("g:EasyGrepCommand") && g:EasyGrepCommand==1 && exists("g:EasyGrepPerlStyle") && g:EasyGrepPerlStyle==1
+        let commandParams = deepcopy(commandParams)
         let commandParams["opt_str_patternprefix"] = '"'
         let commandParams["opt_str_patternpostfix"] = '"'
 

--- a/plugin/EasyGrep.vim
+++ b/plugin/EasyGrep.vim
@@ -34,6 +34,14 @@ let s:EasyGrepModeUser=3
 let s:EasyGrepNumModes=4
 let s:EasyGrepRepositoryList="search:.git,.hg,.svn"
 
+" Whether use perl style regexp
+if exists("g:EasyGrepPerlStyle") && g:EasyGrepPerlStyle==1
+    " perl style regexp require GNU grep
+    if match(system('grep --version'), "GNU") < 0
+        let g:EasyGrepPerlStyle=0
+    endif
+endif
+
 " This is a special mode
 let s:EasyGrepModeMultipleChoice=4
 let s:EasyGrepNumModesWithSpecial = 5
@@ -2575,6 +2583,7 @@ function! s:GetGrepCommandLine(pattern, add, wholeword, count, escapeArgs, filte
         if(has("win32") || has("win64") || has("win95") || has("win16")) && stridx(&shell, "cmd") != -1
             let pattern = substitute(pattern, '"', '""', 'g')
         else
+            let pattern = substitute(pattern, '\%(\\\)\@<!\\\\\[', '\\\[', 'g')
             let pattern = substitute(pattern, '"', '\\"', 'g')
             let pattern = substitute(pattern, '\$', '\\$', 'g')
         endif

--- a/plugin/EasyGrep.vim
+++ b/plugin/EasyGrep.vim
@@ -2582,8 +2582,11 @@ function! s:GetGrepCommandLine(pattern, add, wholeword, count, escapeArgs, filte
         let pattern = substitute(pattern, '|', '\\|', 'g')
         if(has("win32") || has("win64") || has("win95") || has("win16")) && stridx(&shell, "cmd") != -1
             let pattern = substitute(pattern, '"', '""', 'g')
+            let pattern = substitute(pattern, '&', '\^&', 'g')
+            let pattern = substitute(pattern, '\%(\\\)\@<!\\\\\^', '\\\^\^', 'g')
         else
             let pattern = substitute(pattern, '\%(\\\)\@<!\\\\\[', '\\\[', 'g')
+            let pattern = substitute(pattern, '\%(\\\)\@<!\\\\\^', '\\\^', 'g')
             let pattern = substitute(pattern, '"', '\\"', 'g')
             let pattern = substitute(pattern, '\$', '\\$', 'g')
         endif

--- a/plugin/EasyGrep.vim
+++ b/plugin/EasyGrep.vim
@@ -1973,6 +1973,11 @@ function! s:ParseCommandLine(argv)
     let opts["failedparse"] = ""
     let parseopts = 1
 
+    if exists("g:EasyGrepDisableCmdParam") && g:EasyGrepDisableCmdParam==1
+        let opts["pattern"] = a:argv
+        return opts
+    endif
+
     if empty(a:argv)
         return opts
     endif


### PR DESCRIPTION
`:Grep` and `:Replace` would use perl style regexp if:

* EasyGrepCommand is set to 1
* EasyGrepPerlStyle is set to 1
* require: https://github.com/othree/eregex.vim
* require GNU grep greater than 2.5.3

vim style:

```
:Grep \<edit\%(\(ing\)\)\@=
```

perl style:

```
:Grep \<edit(?=(ing))
```