### PR TITLE
fix wrong escape for '-'

### DIFF
--- a/plugin/EasyGrep.vim
+++ b/plugin/EasyGrep.vim
@@ -2587,7 +2587,7 @@ function! s:GetGrepCommandLine(pattern, add, wholeword, count, escapeArgs, filte
         let pattern = substitute(pattern, '\\|', '_t_mslash_t_', 'g')
 
         if exists("g:EasyGrepDisableCmdParam") && g:EasyGrepDisableCmdParam==1
-            let pattern = substitute(pattern, '-', '\\-', 'g')
+            let pattern = substitute(pattern, '^-', '\\-', 'g')
         endif
         let pattern = substitute(pattern, '\\<', '\\b', 'g')
         let pattern = substitute(pattern, '\\>', '\\b', 'g')


### PR DESCRIPTION
bugfix for this: https://github.com/dkprice/vim-easygrep/pull/29#discussion-diff-77451234R1976

this require escape:

```
:Grep - 1
```

however these should not be escaped:

```
:Grep n - 1
:Grep xxx[a-z]
```