### PR TITLE
quick fix window does not appear on consequent search

### DIFF
--- a/autoload/EasyGrep.vim
+++ b/autoload/EasyGrep.vim
@@ -150,7 +150,7 @@ endfunction
 " }}}
 " IsListOpen {{{
 function! EasyGrep#IsListOpen(name)
-    let bufoutput = EasyGrep#GetBuffersOutput(1)
+    let bufoutput = EasyGrep#GetBuffersOutput(0)
     return match(bufoutput, "\\[".a:name." List\\]", 0, 0) != -1
 endfunction
 " }}}


### PR DESCRIPTION
On the first `:Grep` I get list of results. After I close quickfix and do search again, quickfix window does not reopen, unless I call `copen` myself.

The problem is that after closing the quickfix window, its buffer becomes unlisted. The internal `EasyGrep#IsListOpen()` will check for all buffers, including unlisted ones, and so it will not call `copen` considering quickfix is visible.

P.S. probably it makes sense to rename all `Is...Open` functions to `Is...Visible` to remove the confusion.